### PR TITLE
Update box scoring to support multiple owners for a single destroyed box

### DIFF
--- a/hypersonic/model.py
+++ b/hypersonic/model.py
@@ -87,17 +87,24 @@ class Game:
                         box_hit_by[(nx, ny)].add(bomb.owner_id)
                         break  # explosion stops after hitting a box
 
+                    bomb_found = False
+
                     # explosion triggers bombs nearby
                     for other_bomb in self.bombs:
-                        if other_bomb.timer > 0 and other_bomb.x == nx and other_bomb.y == ny:
-                            if (other_bomb.x, other_bomb.y) not in processed_bomb_coordinates:
-                                log.debug(f"{bomb} exploded and detonated immediately {other_bomb}")
-                                other_bomb.timer = 0  # detonate immediately
-                                # bomb exploded so return it to the agent
-                                self.agents[other_bomb.owner_id].bombs_left += 1
-                                if other_bomb not in queue:
-                                    queue.append(other_bomb)
-                                processed_bomb_coordinates.add((other_bomb.x, other_bomb.y))
+                        if other_bomb.x == nx and other_bomb.y == ny:
+                            bomb_found = True
+                            if other_bomb.timer > 0:
+                                if (other_bomb.x, other_bomb.y) not in processed_bomb_coordinates:
+                                    log.debug(f"{bomb} exploded and detonated immediately {other_bomb}")
+                                    other_bomb.timer = 0  # detonate immediately
+                                    # bomb exploded so return it to the agent
+                                    self.agents[other_bomb.owner_id].bombs_left += 1
+                                    if other_bomb not in queue:
+                                        queue.append(other_bomb)
+                                    processed_bomb_coordinates.add((other_bomb.x, other_bomb.y))
+
+                    if bomb_found:
+                        break
 
         # Update the main explosion set for collision detection this turn
         self.explosions = newly_exploded_coordinates

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -103,6 +103,20 @@ def test_single_obstruction_blocks_multiple_explosions(game: Game):
     assert all(a.boxes_blown_up == 1 for a in game.agents), "Both players are awarded"
 
 
+def test_explosion_stops_at_bomb(game: Game):
+    # grid: ...0...
+    #       ...B...
+    #       ...B...
+    # B: bomb, 0: box, .: floor
+    game.grid[0][3] = CellType.BOX.value
+    game.bombs = [Bomb(1, 3, 2), Bomb(0, 3, 1)]
+    game.bombs[0].timer = game.bombs[1].timer = 0
+    game.propagate_explosions(game.bombs)
+    assert game.bombs == [], "Both bombs exploded"
+    assert game.grid[0][3] == CellType.FLOOR.value, "The box is destroyed"
+    assert game.agents[0].boxes_blown_up == 1 and game.agents[1].boxes_blown_up == 0, "Only player 0 gets awarded"
+
+
 def test_path(game: Game):
     for x in range(12, 0, -1):
         next_cell = game.path((5, x), (5, 0))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -72,6 +72,37 @@ def test_propagate_explosion_destroys_boxes(game: Game):
     assert game.grid[by + 2][bx] == CellType.BOX.value, "Explosion propagation stops after a box gets hit"
 
 
+def test_both_players_hit_the_same_box_in_the_same_turn(game: Game):
+    # grid: B0.....
+    #       .......
+    #       .B.....
+    # B: bomb, 0: box, .: floor
+    game.grid[0][1] = CellType.BOX.value
+    game.bombs = [Bomb(0, 0, 0), Bomb(1, 1, 2)]
+    game.bombs[0].timer = game.bombs[1].timer = 0
+    game.propagate_explosions(game.bombs)
+    assert game.bombs == [], "Both bombs exploded"
+    assert game.grid[0][1] == CellType.FLOOR.value, "The box is destroyed"
+    assert all(a.boxes_blown_up == 1 for a in game.agents), "Both players are awarded"
+
+
+def test_single_obstruction_blocks_multiple_explosions(game: Game):
+    # grid: ..0....
+    #       .B00...
+    #       ..B....
+    # B: bomb, 0: box, .: floor
+    game.grid[0][2] = CellType.BOX.value
+    game.grid[1][2] = CellType.BOX.value
+    game.grid[1][3] = CellType.BOX.value
+    game.bombs = [Bomb(0, 1, 1), Bomb(1, 2, 2)]
+    game.bombs[0].timer = game.bombs[1].timer = 0
+    game.propagate_explosions(game.bombs)
+    assert game.bombs == [], "Both bombs exploded"
+    assert game.grid[1][2] == CellType.FLOOR.value, "The box is destroyed"
+    assert game.grid[0][2] == CellType.BOX.value and game.grid[1][3] == CellType.BOX.value, "The other boxes are not destroyed"
+    assert all(a.boxes_blown_up == 1 for a in game.agents), "Both players are awarded"
+
+
 def test_path(game: Game):
     for x in range(12, 0, -1):
         next_cell = game.path((5, x), (5, 0))


### PR DESCRIPTION
## Description:

This PR updates the `propagate_explosions` method to correctly implement the game rule:

- "Once the explosions have been computed, any box hit scores a point to the owner of each explosion. This means that the destruction of 1 box can count for 2 different players." -> found [here](https://www.codingame.com/ide/puzzle/hypersonic#:~:text=Once%20the%20explosions%20have%20been%20computed%2C%20any%20box%20hit%20scores%20a%20point%20to%20the%20owner%20of%20each%20explosion.%20This%20means%20that%20the%20destruction%20of%201%20box%20can%20count%20for%202%20different%20players.)

## Problem
Previously, only the first player whose bomb hit a box would receive credit. Once the box was destroyed, subsequent explosions would not detect it, violating the rule that multiple players can be credited for the same box destruction.

## Solution
- Introduced a `box_hit_by` dictionary to keep track of all players whose explosions hit each box.

- Postponed the actual destruction of boxes until all explosions have been computed.

- Awarded a point to each owner whose explosion contributed to the destruction of a box.