### PR TITLE
Allow multiple agents to place bombs in the same position in the same turn + tests

### DIFF
--- a/hypersonic/model.py
+++ b/hypersonic/model.py
@@ -176,7 +176,7 @@ class Game:
                 if cmd == "BOMB":
                     # bomb placement and movement happen in the same turn
                     if agent.bombs_left > 0:
-                        if not any(b.x == agent.x and b.y == agent.y for b in self.bombs):
+                        if not any(b.x == agent.x and b.y == agent.y and b.timer < Bomb.LIFETIME for b in self.bombs):
                             self.bombs.append(Bomb(agent.id, agent.x, agent.y))
                             agent.bombs_left -= 1
                             log.info(f"{agent.name} places a bomb at ({agent.x}, {agent.y})")


### PR DESCRIPTION
## Description

This pull request introduces a fix and enhancement in the bomb placement logic:

- **Feature:** It is now possible for different agents to place bombs in the same cell if the placement occurs in the same turn.

- **Reason:** This update reflects a more realistic and fair behavior in simultaneous turn-based gameplay, ensuring that agents are not blocked from placing a bomb in a contested spot during the same round.

## Changes

Updated the bomb placement logic to allow multiple bombs in the same cell if placed in the same turn.

## Tests

Two test methods have been added:

1. `test_both_players_place_a_bomb_in_the_same_turn_and_position()`
   Verifies that multiple agents can successfully place bombs in the same cell when the action happens in the same turn.

2. `test_both_players_place_a_bomb_in_the_same_position_but_different_turn()`
   Ensures that if agents attempt to place bombs in the same cell across different turns, only one bomb is placed.
