### PR TITLE
Fix: steal box not working properly

### DIFF
--- a/hypersonic/model.py
+++ b/hypersonic/model.py
@@ -70,12 +70,14 @@ class Game:
         newly_exploded_coordinates: set[tuple[int, int]] = set()
         processed_bomb_coordinates: set[tuple[int, int]] = set((b.x, b.y) for b in exploding_bombs)
         box_hit_by: dict[tuple[int, int], set[int]] = defaultdict(set)  # box coordinates -> set of owner_id
+        exploded_bombs: set[Bomb] = set()
 
         # In this league, players are not hurt by bombs (they are using practice explosives).
 
         queue = deque(exploding_bombs)
         while queue:
             bomb = queue.popleft()
+            exploded_bombs.add(bomb)
             newly_exploded_coordinates.add((bomb.x, bomb.y))  # center of explosion
             for dx, dy in Game.DIRECTIONS:
                 for i in range(1, bomb.range):
@@ -91,6 +93,14 @@ class Game:
 
                     bomb_found = False
 
+                    # explosion stops after hitting a bomb in explosion
+                    for other_bomb in exploding_bombs:
+                        if other_bomb.x == nx and other_bomb.y == ny:
+                            bomb_found = True
+
+                    if bomb_found:
+                        break
+
                     # explosion triggers bombs nearby
                     for other_bomb in self.bombs:
                         if other_bomb.x == nx and other_bomb.y == ny:
@@ -98,7 +108,6 @@ class Game:
                             if other_bomb.timer > 0:
                                 if (other_bomb.x, other_bomb.y) not in processed_bomb_coordinates:
                                     log.debug(f"{bomb} exploded and detonated immediately {other_bomb}")
-                                    other_bomb.timer = 0  # detonate immediately
                                     # bomb exploded so return it to the agent
                                     self.agents[other_bomb.owner_id].bombs_left += 1
                                     if other_bomb not in queue:
@@ -119,7 +128,7 @@ class Game:
                     self.agents[owner_id].boxes_blown_up += 1
 
         # Remove chain-reacted bombs from main list
-        self.bombs = [bomb for bomb in self.bombs if bomb.timer > 0]
+        self.bombs = [bomb for bomb in self.bombs if bomb not in exploded_bombs]
 
     def parse_action(self, agent_id: int, action: str) -> tuple[str, int, int]:
         pack = action.split(maxsplit=3)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -152,6 +152,25 @@ def test_both_players_place_a_bomb_in_the_same_position_but_different_turn(game:
     assert game.grid[1][3] == CellType.FLOOR.value, "The box is destroyed"
 
 
+def test_bomb_steals_box(game: Game):
+    # grid: .......
+    #       .0BB.0.
+    #       ...0...
+    # B: bomb, 0: box, .: floor
+    game.grid[1][1] = CellType.BOX.value
+    game.grid[2][3] = CellType.BOX.value
+    game.grid[1][5] = CellType.BOX.value
+    bomb1 = Bomb(0, 2, 1)
+    bomb2 = Bomb(1, 3, 1)
+    game.bombs = [bomb1,bomb2]
+    bomb1.timer = bomb2.timer = 1
+    game.propagate_explosions(game.tick_bombs())
+    assert game.bombs == [], "Both bombs exploded"
+    assert game.grid[1][1] == game.grid[1][5] == game.grid[2][3] == CellType.FLOOR.value, "All boxes are destroyed"
+    assert game.agents[0].boxes_blown_up == 1, "Player 0 is awarded of 1 box"
+    assert game.agents[1].boxes_blown_up == 2, "Player 1 is awarded of 2 box"
+
+
 def test_path(game: Game):
     for x in range(12, 0, -1):
         next_cell = game.path((5, x), (5, 0))


### PR DESCRIPTION
#### Problem

When two or more bombs had the same timer value and exploded in the same turn, only the ones **still present in `self.bombs`** were considered for propagation. This happened because exploded bombs were already removed from `self.bombs` during `self.tick_bombs()`.

As a result, in `self.propagate_explosions()`, the following loop:

```python
for other_bomb in self.bombs:
```

would **miss bombs that had already exploded in the same turn**, even though they could still block the explosion chain. This led to explosions incorrectly continuing beyond those bombs, violating the intended behavior.

#### Test coverage

This fix addresses cases like the `test_bomb_steals_box`, where two bombs explode in the same turn, one triggering the other. Previously, one bomb could remain incorrectly in `self.bombs`, or explosions could pass through exploded bombs. After this fix, both bombs are properly removed and propagation behaves as expected.
